### PR TITLE
Allow the links to be added to User edit pages as well.

### DIFF
--- a/AdminPageFieldEditLinks.module
+++ b/AdminPageFieldEditLinks.module
@@ -7,6 +7,8 @@
 
 class AdminPageFieldEditLinks extends WireData implements Module {
 
+	private $processes = array('ProcessPageEdit', 'ProcessUser');
+
 	public static function getModuleInfo() {
 
 		return array(
@@ -92,7 +94,7 @@ class AdminPageFieldEditLinks extends WireData implements Module {
 		$this->addHookBefore('InputfieldPage::render', function($event) {
 			$that = $event->object;
 
-			if($that->process == 'ProcessPageEdit' && ($that->editLinks || $that->newPageLink)) { // Only load additional assets if editLinks or newPageLinks are enabled for this field
+			if(in_array($that->process, $this->processes) && ($that->editLinks || $that->newPageLink)) { // Only load additional assets if editLinks or newPageLinks are enabled for this field
 				wire('modules')->get('JqueryUI')->use('modal');
 
 				// load module scripts and styles for the list links
@@ -114,7 +116,7 @@ class AdminPageFieldEditLinks extends WireData implements Module {
 		$this->addHookAfter('InputfieldPage::render', function($event) {
 			$that = $event->object;
 
-			if($that->process == 'ProcessPageEdit') {
+			if(in_array($that->process, $this->processes)) {
 
 				$out = $event->return; // Get the final output from the render method
 				$htmlClasses = '';


### PR DESCRIPTION
In a project I'm working on, a different User template is being used with some additional fields - one of which is a Page field which really benefits from the View/Edit link provided by this module. Needed to include 'ProcessUser' in the code conditional.
