### PR TITLE
Provision of field and page in the iframe URL (Page Edit Modal)

### DIFF
--- a/AdminPageFieldEditLinks.js
+++ b/AdminPageFieldEditLinks.js
@@ -31,7 +31,7 @@ function AdminPageFieldEditLinks() {
 	 */
 	function initEditLinks($wrapper) {
 		// Find all of the InputfieldPage fields that have "add new" links enabled and add links to them (Same for all inputfields)
-		$wrapper.find('.InputfieldPage-newPageLink').each(function () {
+		$wrapper.find('.InputfieldContent > .InputfieldPage-newPageLink').each(function () {
 			addNewLink($(this));
 		});
 
@@ -205,9 +205,12 @@ function AdminPageFieldEditLinks() {
 
 	}
 
-
-
-
+	function getEditUrl($pageField, $id) {
+		var fieldName = $pageField.parents('li.InputfieldPage').children('label').attr('for').split('_')[1];
+		var forPageId = $pageField.parents('form').attr('action').split('=')[1];
+		
+		return config.urls.admin + "page/edit/?id=" + $id + "&forpage=" + forPageId + "&forfield=" + fieldName;		
+	}
 
 	function addEditLinksToBarLists($field) {
 
@@ -216,7 +219,7 @@ function AdminPageFieldEditLinks() {
 			$('ol li', $(this)).not('.itemTemplate').each(function () {
 				var $this = $(this);
 				var id = $this.find('span.itemValue').text();
-				$this.find('span.itemLabel').wrapInner(" <a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + config.urls.admin + "page/edit/?id=" + id + "' target='_blank'></a>").addClass('asmListItemEdit');
+				$this.find('span.itemLabel').wrapInner(" <a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + getEditUrl($(this), id) + "' target='_blank'></a>").addClass('asmListItemEdit');
 
 				if ($this.find('.fa-search').length == 0) {
 					$this.find('span.itemLabel a').append("<i class='fa fa-search' style='margin-left:.5em;'></i>");
@@ -235,7 +238,7 @@ function AdminPageFieldEditLinks() {
 				var id = $this.find('input').val();
 
 				if($this.find('.fa-search').length == 0) {
-					$this.find('span').append("<a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + config.urls.admin + "page/edit/?id=" + id + "' target='_blank'><i class='fa fa-search' style='margin-left:.5em;'></i></a>");
+					$this.find('span').append("<a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + getEditUrl($(this), id) + "' target='_blank'><i class='fa fa-search' style='margin-left:.5em;'></i></a>");
 				}
 			});
 
@@ -252,7 +255,7 @@ function AdminPageFieldEditLinks() {
 			var id = $(this).find('.InputfieldPageAutocompleteData').val();
 
 			if (id > 1) {
-				selectBox.parent().after(" <span class='InputfieldPageEditButton'><a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + config.urls.admin + "page/edit/?id=" + id + "' target='_blank'><i class='fa fa-search'></i> " + config.AdminPageFieldEditLinks.editPageLabel + "</a></span> ");
+				selectBox.parent().after(" <span class='InputfieldPageEditButton'><a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + getEditUrl($(this), id) + "' target='_blank'><i class='fa fa-search'></i> " + config.AdminPageFieldEditLinks.editPageLabel + "</a></span> ");
 			}
 		});
 	}
@@ -265,7 +268,7 @@ function AdminPageFieldEditLinks() {
 			var id = input.val();
 
 			if (id > 1) {
-				input.after(" <span class='InputfieldPageEditButton'><a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + config.urls.admin + "page/edit/?id=" + id + "' target='_blank'><i class='fa fa-search'></i> " + config.AdminPageFieldEditLinks.editPageLabel + "</a></span> ");
+				input.after(" <span class='InputfieldPageEditButton'><a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + getEditUrl($(this), id) + "' target='_blank'><i class='fa fa-search'></i> " + config.AdminPageFieldEditLinks.editPageLabel + "</a></span> ");
 			}
 		});
 	}
@@ -280,7 +283,7 @@ function AdminPageFieldEditLinks() {
 			var id = $(this).find('select option:selected').val();
 
 			if (id > 1) {
-				selectBox.after(" <span class='InputfieldPageEditButton'><a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + config.urls.admin + "page/edit/?id=" + id + "' target='_blank'><i class='fa fa-search'></i> " + config.AdminPageFieldEditLinks.editPageLabel + "</a></span> ");
+				selectBox.after(" <span class='InputfieldPageEditButton'><a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + getEditUrl($(this), id) + "' target='_blank'><i class='fa fa-search'></i> " + config.AdminPageFieldEditLinks.editPageLabel + "</a></span> ");
 			}
 		});
 	}
@@ -288,11 +291,14 @@ function AdminPageFieldEditLinks() {
 	function addEditLinksToAsmSelect($field) {
 		$field.each(function () {
 			var pageField = $(this);
+			var fieldName = pageField.parents('li.InputfieldPage').children('label').attr('for').split('_')[1];
+			var forPageId = pageField.parents('form').attr('action').split('=')[1];
+			
 			$('.asmListItem', this).each(function () {
 				var rel = $(this).attr('rel');
 				var option = pageField.find('.asmSelect [rel="' + rel + '"]').first();
 				var id = option.val();
-				$(this).find('span.asmListItemLabel').wrapInner(" <a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + config.urls.admin + "page/edit/?id=" + id + "' target='_blank'></a>").addClass('asmListItemEdit');
+				$(this).find('span.asmListItemLabel').wrapInner(" <a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + getEditUrl(pageField, id) + "' target='_blank'></a>").addClass('asmListItemEdit');
 
 				if ($(this).find('.fa-search').length == 0) {
 					$(this).find('span.asmListItemLabel a').append("<i class='fa fa-search' style='margin-left:.5em;'></i>");
@@ -308,7 +314,7 @@ function AdminPageFieldEditLinks() {
 			var id = $(this).data('pageid');
 
 			if (id > 1) {
-				$(this).after(" <span class='InputfieldPageEditButton'><a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + config.urls.admin + "page/edit/?id=" + id + "' target='_blank'><i class='fa fa-search'></i> " + config.AdminPageFieldEditLinks.editPageLabel + "</a></span> ");
+				$(this).after(" <span class='InputfieldPageEditButton'><a class='pw-modal pw-modal-medium' data-buttons='#submit_save, #submit_publish, #submit_save_unpublished' data-autoclose href='" + getEditUrl($(this), id) + "' target='_blank'><i class='fa fa-search'></i> " + config.AdminPageFieldEditLinks.editPageLabel + "</a></span> ");
 			}
 		});
 	}
@@ -507,6 +513,7 @@ function AdminPageFieldEditLinks() {
 	function addNewLink($field) {
 		$field.each(function () {
 			$('.InputfieldPageNewButton', this).remove(); // If the button already exists, remove it
+			$('.InputfieldPageAddButton', this).remove(); // If the button already exists, remove it
 			var parentId = $(this).attr('data-parent');
 			var templateId = $(this).attr('data-template');
 

--- a/AdminPageFieldEditLinks.module
+++ b/AdminPageFieldEditLinks.module
@@ -77,7 +77,7 @@ class AdminPageFieldEditLinks extends WireData implements Module {
 			if($that->newPageLink) {
 				$event->return->addable->setAttribute('checked',false);
 				$event->return->addable->setAttribute('disabled',true);
-				$event->return->addable->notes = __('DISABLED: Not compatible with AdminPageFieldEditLinks');
+				$event->return->addable->notes = sprintf(__('DISABLED: Not compatible with module %s if link to create new pages is enabled!'), '**AdminPageFieldEditLinks**');
 			}
 			// $event->return->remove('addable');
 

--- a/AdminPageFieldEditLinks.module
+++ b/AdminPageFieldEditLinks.module
@@ -2,7 +2,7 @@
 /**
  * Adds edit links to Page fields so that pages can be added or edited in a modal window without leaving the edit screen
  *
- * authors: Mike Spooner (thetuningspoon), macrura
+ * authors: Mike Spooner (thetuningspoon), macrura, kixe
 */
 
 class AdminPageFieldEditLinks extends WireData implements Module {
@@ -11,7 +11,7 @@ class AdminPageFieldEditLinks extends WireData implements Module {
 
 		return array(
 			'title' => 'Page Field Edit Links',
-			'version' => '3.1.3',
+			'version' => '3.1.4',
 			'summary' => 'Creates edit links on Page fields so that pages can be added or edited in a modal window without leaving the edit screen',
 			'author' => 'Mike Spooner (thetuningspoon), macrura',
 			'href' => 'http://processwire.com',
@@ -55,11 +55,31 @@ class AdminPageFieldEditLinks extends WireData implements Module {
 		}
 
 		/**
+		 * Remove default 'create new' link if 'add' link is provided
+		 *
+		 */
+		$this->addHookBefore("InputfieldPage::renderAddable", function($event) {
+			$that = $event->object;
+			if($that->newPageLink) {
+				$event->replace = true;
+				$event->return = '';
+			}
+		});
+
+		/**
 		 * Adds additional options to the InputfieldPage edit screen.
 		 *
 		 */
 		$this->addHookAfter("InputfieldPage::getConfigInputfields", function($event) {
 			$that = $event->object;
+
+			// disable option to provide 'create new' link if 'add' link is already there
+			if($that->newPageLink) {
+				$event->return->addable->setAttribute('checked',false);
+				$event->return->addable->setAttribute('disabled',true);
+				$event->return->addable->notes = __('DISABLED: Not compatible with AdminPageFieldEditLinks');
+			}
+			// $event->return->remove('addable');
 
 			if($that->hasFieldtype !== false) {
 				$field = wire('modules')->get('InputfieldCheckbox');


### PR DESCRIPTION
I am currently working on a module that will allow additional data to be added to the page field record. These are added to the page object as runtime properties and are available via the API. The **AdminPageFieldEditLinks** module is ideal for conveniently editing the data, as I can insert tabs and fields into the editing modal using a hook and also read them out using a hook and save them in the page field data record. This already works great in my development environment. I have extended the AdminPageFieldEditLinks module so that GET parameters are passed to the modal via URL, which provide information about the page and the field currently being edited. Since I don't want to reinvent the wheel, it would be nice if this extension were available by default.

Only a few changes to the Javascript file are required for implementation:

I added a function which generates the edit URL, and provided the parameters 'forpage' and 'forfield' as href attr in each edit link.

```
	function getEditUrl($pageField, $id) {
		var fieldName = $pageField.parents('li.InputfieldPage').children('label').attr('for').split('_')[1];
		var forPageId = $pageField.parents('form').attr('action').split('=')[1];
		
		return config.urls.admin + "page/edit/?id=" + $id + "&forpage=" + forPageId + "&forfield=" + fieldName;		
	}
```

It would be great if you could implement this. As a reward, there will be a very useful module.

![Bildschirmfoto 2021-06-03 um 10 35 29](https://user-images.githubusercontent.com/4683120/120614392-78093400-c457-11eb-9e57-95f4ca6603bc.png)
