### PR TITLE
Fix “TypeError: Illegal offset type in isset or empty” in PHP 8

### DIFF
--- a/AdminPageFieldEditLinks.module
+++ b/AdminPageFieldEditLinks.module
@@ -175,14 +175,14 @@ class AdminPageFieldEditLinks extends WireData implements Module {
 
 			if($that->editLinks) {
                 $htmlClasses .= "InputfieldPage-editLinks";
-                $htmlDataAttributes .= "data-pageid='{$that->hasPage->get($that->hasField)->id}'";
+                $htmlDataAttributes .= "data-pageid='{$that->hasPage->get($that->hasField->name)->id}'";
             }
 			if($that->newPageLink) {
 				$newPageParent = $that->newPageParent ?: $that->parent_id;
 				$htmlClasses .= " InputfieldPage-newPageLink";
 				$htmlDataAttributes .= " data-parent='{$newPageParent}' data-template='{$that->template_id}'";
 			}
-            
+
             $event->return = "<span {$htmlDataAttributes} class='$htmlClasses'>{$event->return}</span>";
 		});
 


### PR DESCRIPTION
Hey there. This is just a very quick fix for a warning I introduced some time ago that turned into a TypeError in Page::get() with PHP 8.